### PR TITLE
add support serverless.yml mapping(key-value) httpApi parameter

### DIFF
--- a/src/Router.php
+++ b/src/Router.php
@@ -26,12 +26,18 @@ class Router
     {
         $routes = [];
         foreach ($serverlessConfig['functions'] as $function) {
-            $pattern = $function['events'][0]['httpApi'] ?? null;
-            if (! $pattern) continue;
-            if (is_array($pattern) && isset($pattern['method']) && isset($pattern['path'])) {
-                $pattern = "${pattern['method']} ${pattern['path']}";
+            foreach ($function['events'] as $event) {
+                $pattern = null;
+                $httpApi = $event['httpApi'];
+                if (is_string($httpApi)) {
+                    $pattern = $httpApi;
+                }
+                if (is_array($httpApi) && $httpApi['method'] && $httpApi['path']) {
+                    $pattern = "${httpApi['method']} ${httpApi['path']}";
+                }
+                if (! $pattern) continue;
+                $routes[$pattern] = $function['handler'];
             }
-            $routes[$pattern] = $function['handler'];
         }
         return new self($routes);
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -28,6 +28,9 @@ class Router
         foreach ($serverlessConfig['functions'] as $function) {
             $pattern = $function['events'][0]['httpApi'] ?? null;
             if (! $pattern) continue;
+            if (is_array($pattern) && isset($pattern['method']) && isset($pattern['path'])) {
+                $pattern = "${pattern['method']} ${pattern['path']}";
+            }
             $routes[$pattern] = $function['handler'];
         }
         return new self($routes);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -58,22 +58,18 @@ class RouterTest extends TestCase
                         [
                             'httpApi' => 'GET /',
                         ],
-                    ],
-                ],
-            ],
-        ];
-        $router1 = Router::fromServerlessConfig($stringHttpApiParameter);
-
-        self::assertEquals('home', $router1->match($this->request('GET', '/'))[0]);
-
-        $mappingHttpApiParameter = [
-            'functions' => [
-                'home' => [
-                    'handler' => 'home',
-                    'events' => [
+                        [
+                            'httpApi' => 'POST /',
+                        ],
                         [
                             'httpApi' => [
-                                'method' => 'GET',
+                                'method' => 'OPTION',
+                                'path' => '/',
+                            ],
+                        ],
+                        [
+                            'httpApi' => [
+                                'method' => 'DELETE',
                                 'path' => '/',
                             ],
                         ],
@@ -81,10 +77,12 @@ class RouterTest extends TestCase
                 ],
             ],
         ];
-        $router2 = Router::fromServerlessConfig($mappingHttpApiParameter);
-        self::assertEquals('home', $router2->match($this->request('GET', '/'))[0]);
+        $router = Router::fromServerlessConfig($stringHttpApiParameter);
 
-        self::assertEquals($router1, $router2);
+        self::assertEquals('home', $router->match($this->request('GET', '/'))[0]);
+        self::assertEquals('home', $router->match($this->request('POST', '/'))[0]);
+        self::assertEquals('home', $router->match($this->request('OPTION', '/'))[0]);
+        self::assertEquals('home', $router->match($this->request('DELETE', '/'))[0]);
     }
 
     private function request(string $method, string $path): ServerRequestInterface

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -48,6 +48,45 @@ class RouterTest extends TestCase
         self::assertEquals('def', $router->match($this->request('GET', '/abc/def'))[0]);
     }
 
+    public function test routing from serverless config(): void
+    {
+        $stringHttpApiParameter = [
+            'functions' => [
+                'home' => [
+                    'handler' => 'home',
+                    'events' => [
+                        [
+                            'httpApi' => 'GET /',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $router1 = Router::fromServerlessConfig($stringHttpApiParameter);
+
+        self::assertEquals('home', $router1->match($this->request('GET', '/'))[0]);
+
+        $mappingHttpApiParameter = [
+            'functions' => [
+                'home' => [
+                    'handler' => 'home',
+                    'events' => [
+                        [
+                            'httpApi' => [
+                                'method' => 'GET',
+                                'path' => '/',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $router2 = Router::fromServerlessConfig($mappingHttpApiParameter);
+        self::assertEquals('home', $router2->match($this->request('GET', '/'))[0]);
+
+        self::assertEquals($router1, $router2);
+    }
+
     private function request(string $method, string $path): ServerRequestInterface
     {
         return new ServerRequest($method, $path);


### PR DESCRIPTION
why: see #6 

I have written test code where the value of `httpApi` is a string or mapping. (But I don't think it's best to write arrays in the test code).