### PR TITLE
Update router and handler to support advanced use case (routing with API Gateway V1/V2) with event driven runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,47 @@ The application will be available at [http://localhost:8000/](http://localhost:8
 
 Routes will be parsed from `serverless.yml` in the current directory.
 
+### Function Example
+You can use this template as a sample for a function of your application.
+Context will be mapped from `lambda-context` attribute of the request as stated [here](https://bref.sh/docs/use-cases/http/advanced-use-cases#lambda-event-and-context). 
+
+```php
+<?php
+
+use Bref\Context\Context;
+use Nyholm\Psr7\Response;
+
+require 'vendor/autoload.php';
+
+class Handler implements \Bref\Event\Handler
+{
+    public function handle($event, ?Context $context): Response
+    {
+        $attributes = $event->getAttributes();
+        $queryParams = $event->getQueryParams();
+        $parsedBody = $event->getParsedBody();
+
+        $message = [
+            "message" =>'Go Serverless v3.0! Your function executed successfully!',
+            "context" => $context,
+            "input" => [
+                "attributes"=>$attributes,
+                "queryParams"=>$queryParams,
+                "parsedBody"=>$parsedBody
+            ]
+        ];
+
+        $status = 200;
+
+        return new Response($status, [], json_encode($message));
+    }
+}
+
+return new Handler();
+
+```
+
+
 ### Assets
 
 By default, static assets are served from the current directory.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit colors="true"
-         bootstrap="./vendor/autoload.php">
-
-    <testsuites>
-        <testsuite name="Test suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -44,7 +44,8 @@ class Handler
         $request = $this->requestFromGlobals();
         [$handler, $request] = $router->match($request);
         $controller = $handler ? $container->get($handler) : new NotFound;
-        $response = $controller->handle($request);
+        $context = $request->getAttribute('lambda-event')?->getRequestContext();
+        $response = $controller->handle($request,$context);
         (new ResponseEmitter)->emit($response);
 
         return null;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -45,7 +45,7 @@ class Handler
         [$handler, $request] = $router->match($request);
         $controller = $handler ? $container->get($handler) : new NotFound;
         $context = $request->getAttribute('lambda-event')?->getRequestContext();
-        $response = $controller->handle($request,$context);
+        $response = $controller->handle($request, $context);
         (new ResponseEmitter)->emit($response);
 
         return null;

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -4,6 +4,7 @@ namespace Bref\DevServer;
 
 use Bref\Bref;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -46,6 +47,9 @@ class Handler
         $controller = $handler ? $container->get($handler) : new NotFound;
         $context = $request->getAttribute('lambda-event')?->getRequestContext();
         $response = $controller->handle($request, $context);
+        if (is_array($response)) {
+            $response = new Response(200, [], $response['body']);
+        }
         (new ResponseEmitter)->emit($response);
 
         return null;

--- a/src/Router.php
+++ b/src/Router.php
@@ -56,7 +56,7 @@ class Router
             if (isset($event['http'])) { //Search for API Gateway v1 syntax
                 $pattern = $event['http'];
                 break;
-            } elseif (isset($event['httpApi'])) { //Or for API Gateway v1 syntax
+            } elseif (isset($event['httpApi'])) { //Or for API Gateway v2 syntax
                 $pattern = $event['httpApi'];
                 break;
             }

--- a/src/Router.php
+++ b/src/Router.php
@@ -61,6 +61,7 @@ class Router
                 return $event['httpApi'];
             }
         }
+        return null;
     }
 
     private static function patternToString(array $pattern): string
@@ -144,7 +145,7 @@ class Router
         }
 
         $pathRegex = $this->patternToRegex($pathPattern);
-        preg_match($pathRegex, $requestPath, $matches);
+        preg_match($pathRegex, ltrim($requestPath, '/'), $matches);
         foreach ($matches as $name => $value) {
             $request = $request->withAttribute($name, $value);
         }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -73,6 +73,86 @@ class RouterTest extends TestCase
         self::assertSame('api.php', $router->match($this->request('PUT', '/tests/1'))[0]);
     }
 
+    /**
+     * @test
+     */
+    public function test_routing_with_api_gateway_v1_wildcard_config(): void
+    {
+        $config = <<<YAML
+        functions:
+          api:
+            handler: api.php
+            events:
+              - http:
+                  method: '*'
+                  path: '*'
+        YAML;
+
+        $config = Yaml::parse($config);
+        $router = Router::fromServerlessConfig($config);
+
+        self::assertSame('api.php', $router->match($this->request('GET', '/'))[0]);
+        self::assertSame('api.php', $router->match($this->request('POST', '/'))[0]);
+        self::assertSame('api.php', $router->match($this->request('GET', '/tests/1'))[0]);
+        self::assertSame('api.php', $router->match($this->request('PUT', '/tests/1'))[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function test_routing_with_api_gateway_v1_specific_method_config(): void
+    {
+        $config = <<<YAML
+        functions:
+          hello:
+            handler: hello.php
+            events:
+              - http:
+                  method: 'GET'
+                  path: '/hello'
+        YAML;
+
+        $config = Yaml::parse($config);
+        $router = Router::fromServerlessConfig($config);
+
+        self::assertSame('hello.php', $router->match($this->request('GET', '/hello'))[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function test_routing_with_api_gateway_v1_file_config(): void
+    {
+        $config = <<<YAML
+        functions:
+          - \${file(./tests/function/hello/v1serverless.yml)}
+        YAML;
+
+        $config = Yaml::parse($config);
+        $router = Router::fromServerlessConfig($config);
+
+        self::assertSame('hello.php', $router->match($this->request('GET', '/hello'))[0]);
+    }
+
+    /**
+     * @test
+     */
+    public function test_routing_with_api_gateway_v2_file_config(): void
+    {
+        $config = <<<YAML
+        functions:
+          - \${file(./tests/function/hello/v2serverless.yml)}
+        YAML;
+
+        $config = Yaml::parse($config);
+        $router = Router::fromServerlessConfig($config);
+
+        self::assertSame('hello.php', $router->match($this->request('GET', '/'))[0]);
+        self::assertSame('hello.php', $router->match($this->request('POST', '/'))[0]);
+        self::assertSame('hello.php', $router->match($this->request('GET', '/tests/1'))[0]);
+        self::assertSame('hello.php', $router->match($this->request('PUT', '/tests/1'))[0]);
+    }
+
     private function request(string $method, string $path): ServerRequestInterface
     {
         return new ServerRequest($method, $path);

--- a/tests/function/hello/v1serverless.yml
+++ b/tests/function/hello/v1serverless.yml
@@ -1,0 +1,13 @@
+hello:
+  handler: hello.php #function handler
+  events: #events
+    #keep warm event
+    - schedule:
+        rate: rate(5 minutes)
+        enabled: true
+        input:
+          warmer: true
+    #api gateway event
+    - http:
+        path: /hello #api endpoint path
+        method: 'GET' #api endpoint method

--- a/tests/function/hello/v2serverless.yml
+++ b/tests/function/hello/v2serverless.yml
@@ -1,0 +1,13 @@
+hello:
+  handler: hello.php #function handler
+  events: #events
+    #keep warm event
+    - schedule:
+        rate: rate(5 minutes)
+        enabled: true
+        input:
+          warmer: true
+    #api gateway event
+    - httpApi:
+        method: '*'
+        path: '*'


### PR DESCRIPTION
Hi, is this package still mantained?

As for Bref documentation we should be able to use this repo if we are running event driven functions for an HTTP Application routed by API Gateway (https://bref.sh/docs/local-development/event-driven-functions#api-gateway-local-development), to emulate API Gateway locally.

Basically if we are in this scenario https://bref.sh/docs/use-cases/http/advanced-use-cases#with-the-event-driven-function-runtime (as an example developing a REST API) using a simple function like 

```php
<?php

use Bref\Context\Context;
use Nyholm\Psr7\Response;

require 'vendor/autoload.php';

class Handler implements \Bref\Event\Handler
{
    public function handle($event, ?Context $context): Response
    {
        $attributes = $event->getAttributes();
        $queryParams = $event->getQueryParams();
        $parsedBody = $event->getParsedBody();

        $message = [
            "message" =>'Bref! Your function executed successfully!',
            "context" => $context,
            "input" => [
                "attributes"=>$attributes,
                "queryParams"=>$queryParams,
                "parsedBody"=>$parsedBody
            ]
        ];

        $status = 200;

        return new Response($status, [], json_encode($message));
    }
}

return new Handler();

```

As it seems to me that I can't get serverless-offline work with Bref (I've tried without success mostly beacuse provided.al2 is not a supported runtime, and I've read a bunch of topic that is not on the roadmap), and as stated by documentation "serverless bref:local is a bit unpractical because you need to manually craft HTTP events in JSON", I've done some changes in this repo source code:
- In router, I've added a function which parse all events (not only the first one), so that a warmer or other triggers won't be a problem if added before an http event. I've also added a line to recognize "http" events for API Gateway V1 routing, so that serverless.yaml will be parsed also for those (not only for "httpApi" events for API Gateway V2 routing).
- In router, I've added another function to parse separated file inclusion for serverless.yml if servelress syntax to include file is recognized ( ${file(...)} )
- In handler, I've passed a second parameter to the handler to get "Context" from "lambda-context" attribute as stated here https://bref.sh/docs/use-cases/http/advanced-use-cases#lambda-event-and-context

This should improve this codebase so that this dev-server is working with a definition like this

Root `serverless.yml`
```yaml
## Define atomic functions
functions:
  ## Hello function
  - ${file(./src/function/hello/serverless.yml)}
```

Separate `/src/function/hello/serverless.yml`
```yaml
hello:
  handler: src/function/hello/index.php #function handler
  package: #package patterns
    include:
      - "!**/*"
      - src/function/hello/**
  events: #events
    #keep warm event
    - schedule:
        rate: rate(5 minutes)
        enabled: ${strToBool(${self:custom.scheduleEnabled.${env:STAGE_NAME}})}
        input:
          warmer: true
    #api gateway event
    - http:
        path: /hello #api endpoint path
        method: 'GET' #api endpoint method
        cors: true
        caching: #cache
          enabled: false
        documentation:
          summary: "/hello"
          description: "Just a sample GET to say hello"
          methodResponses:
            - statusCode: 200
              responseBody:
                description: "A successful response"
              responseModels:
                application/json: "HelloResponse"
            - statusCode: 500
              responseBody:
                description: "Internal Server Error"
              responseModels:
                application/json: "ErrorResponse"
            - statusCode: 400
              responseBody:
                description: "Request error"
              responseModels:
                application/json: "BadRequestResponse"

```

Hope this helps.