### PR TITLE
[IPT-5007] Prep: Get bref dev server working with Nyholm/psr7 ^1.8

### DIFF
--- a/.docker/tools/composer.sh
+++ b/.docker/tools/composer.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "$0")
+
+${DIR}/run.sh composer "$@"

--- a/.docker/tools/run.sh
+++ b/.docker/tools/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o allexport
+source .env
+set +o allexport
+
+COMPOSER_AUTH="{
+    \"github-oauth\": {
+        \"github.com\": \"${COMPOSER_TOKEN}\"
+    }
+}"
+
+docker run \
+    --rm \
+    --interactive \
+    --volume $PWD:/app \
+    --network ihasco_local \
+    --workdir /app \
+    --env COMPOSER_AUTH="${COMPOSER_AUTH}" \
+    jitesoft/phpunit:8.4 "$@"

--- a/.docker/tools/test.sh
+++ b/.docker/tools/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+DIR=$(dirname "$0")
+
+${DIR}/composer.sh run test "$@"

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+COMPOSER_TOKEN="<set Composer token here>"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /composer.phar
 /composer.lock
 /.phpunit.result.cache
+.idea
+.env

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "mnapoli/silly": "^1.5",
         "nyholm/psr7": "^1.0",
         "nyholm/psr7-server": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "symfony/console": "^4.0|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,15 @@
             "Bref\\DevServer\\Test\\": "tests/"
         }
     },
+    "scripts": {
+      "test": "./vendor/bin/phpunit"
+    },
     "require": {
-        "php": ">=8.0",
+        "php": "^8.4",
         "bref/bref": "^1.0 || ^2.0",
         "filp/whoops": "^2.5",
         "mnapoli/silly": "^1.5",
-        "nyholm/psr7": "^1.0",
+        "nyholm/psr7": "^1.8",
         "nyholm/psr7-server": "^1.0",
         "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit colors="true"
-         bootstrap="./vendor/autoload.php">
-
-    <testsuites>
-        <testsuite name="Test suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Router.php
+++ b/src/Router.php
@@ -115,7 +115,7 @@ class Router
 
         $pathRegex = $this->patternToRegex($pathPattern);
         preg_match($pathRegex, $requestPath, $matches);
-        foreach ($matches as $name => $value) {
+        foreach (array_filter($matches, fn($key) => is_string($key),ARRAY_FILTER_USE_KEY) as $name => $value) {
             $request = $request->withAttribute($name, $value);
         }
 


### PR DESCRIPTION
This pull request introduces several improvements to the project's PHP tooling and dependency management, as well as updates to test configuration and routing logic. The main themes are enhancements to Docker tooling for Composer and PHPUnit, updates to PHP dependencies, improved test configuration, and a small fix to path parameter handling in the router.

**Docker tooling and Composer integration:**

* Added new scripts (`.docker/tools/composer.sh`, `.docker/tools/run.sh`, `.docker/tools/test.sh`) to streamline running Composer and PHPUnit commands inside Docker containers, including support for GitHub authentication via a Composer token. (`[[1]](diffhunk://#diff-5eca7bf3f035b3da7d202cd9a80ad5ed0923938d5c3f78b344cd2a6a2d28436bR1-R5)`, `[[2]](diffhunk://#diff-f4bcc50a55e8e4d89cabed6e83e72b01bf1b0310ec1ec837aa385aa02a135cc9R1-R20)`, `[[3]](diffhunk://#diff-4b090c0f190917cf8eba410629b0f31a39de37a5136766cc15083aa251cd770eR1-R5)`)
* Added `COMPOSER_TOKEN` to `.env.sample` to facilitate secure authentication for Composer operations. (`[.env.sampleR1](diffhunk://#diff-088d9f35d23a4347d221d71dd49b02b95001dff4abe637a40fe0bc04d502049cR1)`)

**Dependency and test configuration updates:**

* Updated `composer.json` to require PHP 8.4+, bump versions for several dependencies, and add a `test` script for running PHPUnit. (`[composer.jsonR20-R30](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R20-R30)`)
* Modernized `phpunit.xml.dist` to use the latest schema and coverage configuration, replacing deprecated filter/whitelist settings. (`[phpunit.xml.distL2-L16](diffhunk://#diff-e35810879ec42bdd81797b3ccb72f6de28a8b4a0e3bfdba43183e133e866b892L2-L16)`)

**Routing logic improvement:**

* Improved path parameter extraction in `src/Router.php` by filtering matches to only use string keys, ensuring correct assignment of route parameters. (`[src/Router.phpL118-R118](diffhunk://#diff-95fd90c4e82eb78455558373d51bfb443010152c93eb52b9ff9730cff2a80c96L118-R118)`)